### PR TITLE
adapt share folder for the click package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ include(GNUInstallDirs)
 if(CLICK_MODE)
   set(CMAKE_INSTALL_PREFIX "/")
   set(CMAKE_INSTALL_BINDIR "/")
-  set(CMAKE_INSTALL_FULL_DATADIR "share/")
+  set(CMAKE_INSTALL_FULL_DATADIR "./share")
   add_definitions("-DCLICK_MODE")
 endif()
 


### PR DESCRIPTION
Hi Lionel,
the adaption to the clickable.json is really helpful. (and also the readme adaption, we just have to rename some of the "webbrowser-app" with "morph-browser" later. Not sure of the debugging is possible like it was with webbrowser-app)

For quite some time I've been wondering, why `clickable desktop` does not work (it always runs /usr/bin/morph-browser instead of the built version), and I think with the adaption of CMakeLists and clickable (https://gitlab.com/balcy/clickable/commit/5d193e4542d276499f818526dd41da0e61c5a419) it will work.
So because we adapt clickable.json with this PR, the other adaption can be combined with it.

